### PR TITLE
API-3483: Added a new way to create the header validator filter with …

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,11 +50,33 @@ AntiFraudHeadersValidator.validate(headerValidators)(request) match {
 ```
 
 If you use the `AntiFraudHeadersValidatorActionFilter`, your controller would look simpler.
-We suggest two alternative implementations.
+You just have to wrap your code with the filter, which will return a precondition failed (412) error if the validation of the headers fails.
+We suggest three alternative implementations.
 
-1. By creating the Play `ActionFilter` from the required header names:
+1. By creating the Play `ActionFilter` using the default headers:
 ``` scala
-import uk.gov.hmrc.fraudprevention.AntiFraudHeadersValidator
+import uk.gov.hmrc.fraudprevention.AntiFraudHeadersValidatorActionFilter
+
+// this can be reused for each controller that require the same headers
+lazy val fraudPreventionActionFilter = AntiFraudHeadersValidatorActionFilter.actionFilterWithDefaultHeaders
+
+def handleRequest(): Action[AnyContent] = fraudPreventionActionFilter.async { implicit request =>
+  // controller code to add
+}
+```
+
+The default headers are:
+- Gov-Client-Device-ID
+- Gov-Client-User-IDs
+- Gov-Client-Timezone
+- Gov-Client-Local-IPs
+- Gov-Vendor-Version
+- Gov-Vendor-License-IDs
+- Gov-Client-Connection-Method
+
+2. By creating the Play `ActionFilter` from the required header names:
+``` scala
+import uk.gov.hmrc.fraudprevention.AntiFraudHeadersValidatorActionFilter
 
 lazy val requiredHeaders = List("Gov-Client-Public-Port")
 
@@ -66,9 +88,9 @@ def handleRequest(): Action[AnyContent] = fraudPreventionActionFilter.async { im
 }
 ```
 
-2. By creating the Play `ActionFilter` from the header validators:
+3. By creating the Play `ActionFilter` from the header validators:
 ``` scala
-import uk.gov.hmrc.fraudprevention.AntiFraudHeadersValidator
+import uk.gov.hmrc.fraudprevention.AntiFraudHeadersValidatorActionFilter
 import uk.gov.hmrc.fraudprevention.headervalidators.impl.GovClientPublicPortHeaderValidator
 
 lazy val headerValidators = List(GovClientPublicPortHeaderValidator)

--- a/src/main/scala/uk/gov/hmrc/fraudprevention/headervalidators/impl/BasicHeaderValidator.scala
+++ b/src/main/scala/uk/gov/hmrc/fraudprevention/headervalidators/impl/BasicHeaderValidator.scala
@@ -1,0 +1,53 @@
+/*
+ * Copyright 2018 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package uk.gov.hmrc.fraudprevention.headervalidators.impl
+
+import uk.gov.hmrc.fraudprevention.headervalidators.HeaderValidator
+
+trait BasicHeaderValidator extends HeaderValidator {
+  override protected def validateHeaderValue(headerValue: String): Either[String, Unit] = {
+    if (headerValue.isEmpty) Left(s"$headerName must not be empty") else Right(())
+  }
+}
+
+object GovClientDeviceIdHeaderValidator extends BasicHeaderValidator {
+  override final val headerName: String = "Gov-Client-Device-ID"
+}
+
+object GovClientUserIdHeaderValidator extends BasicHeaderValidator {
+  override final val headerName: String = "Gov-Client-User-IDs"
+}
+
+object GovClientTimezoneHeaderValidator extends BasicHeaderValidator {
+  override final val headerName: String = "Gov-Client-Timezone"
+}
+
+object GovClientLocalIpHeaderValidator extends BasicHeaderValidator {
+  override final val headerName: String = "Gov-Client-Local-IPs"
+}
+
+object GovVendorVersionHeaderValidator extends BasicHeaderValidator {
+  override final val headerName: String = "Gov-Vendor-Version"
+}
+
+object GovVendorLicenseIdHeaderValidator extends BasicHeaderValidator {
+  override final val headerName: String = "Gov-Vendor-License-IDs"
+}
+
+object GovClientConnectionMethodHeaderValidator extends BasicHeaderValidator {
+  override final val headerName: String = "Gov-Client-Connection-Method"
+}

--- a/src/test/scala/uk/gov/hmrc/fraudprevention/headervalidators/AntiFraudHeadersValidatorActionFilterSpec.scala
+++ b/src/test/scala/uk/gov/hmrc/fraudprevention/headervalidators/AntiFraudHeadersValidatorActionFilterSpec.scala
@@ -1,0 +1,66 @@
+/*
+ * Copyright 2018 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package uk.gov.hmrc.fraudprevention.headervalidators
+
+import akka.stream.Materializer
+import play.api.http.Status.{NO_CONTENT, PRECONDITION_FAILED}
+import play.api.libs.json.Json
+import play.api.mvc.Results.NoContent
+import play.api.mvc._
+import play.api.test.FakeRequest
+import uk.gov.hmrc.fraudprevention.AntiFraudHeadersValidatorActionFilter._
+import uk.gov.hmrc.fraudprevention.headervalidators.impl._
+import uk.gov.hmrc.play.test.{UnitSpec, WithFakeApplication}
+
+class AntiFraudHeadersValidatorActionFilterSpec extends UnitSpec with WithFakeApplication {
+
+  private implicit val materializer: Materializer = fakeApplication.materializer
+
+  private val defaultHeaderValidators: List[HeaderValidator] = List(
+    GovClientDeviceIdHeaderValidator, GovClientUserIdHeaderValidator, GovClientTimezoneHeaderValidator,
+    GovClientLocalIpHeaderValidator, GovVendorVersionHeaderValidator, GovVendorLicenseIdHeaderValidator,
+    GovClientConnectionMethodHeaderValidator
+  )
+
+  Map(
+    "action filter with default headers" -> actionFilterWithDefaultHeaders,
+    "action filter from header validators" -> actionFilterFromHeaderValidators(defaultHeaderValidators),
+    "action filter from header names" -> actionFilterFromHeaderNames(defaultHeaderValidators.map(hv => hv.headerName))
+  ) foreach { case(filterName, actionFilter) =>
+
+    filterName should {
+      "return a successful response if no validations fail" in {
+        val action: Action[AnyContent] = actionFilter(NoContent)
+        val request = FakeRequest().withHeaders(defaultHeaderValidators.map(hd => hd.headerName -> "value"):_*)
+
+        val result: Result = await(action(request))
+
+        status(result) shouldBe NO_CONTENT
+      }
+
+      "return an error response if any validations fail" in {
+        val action: Action[AnyContent] = actionFilter(NoContent)
+        val request = FakeRequest().withHeaders(defaultHeaderValidators.tail.map(hd => hd.headerName -> "value"):_*)
+
+        val result: Result = await(action(request))
+
+        status(result) shouldBe PRECONDITION_FAILED
+        jsonBodyOf(result) shouldBe Json.obj("code" -> "MISSING_OR_INVALID_HEADERS", "message" -> "Header Gov-Client-Device-ID is missing")
+      }
+    }
+  }
+}

--- a/src/test/scala/uk/gov/hmrc/fraudprevention/headervalidators/impl/BasicHeaderValidatorSpec.scala
+++ b/src/test/scala/uk/gov/hmrc/fraudprevention/headervalidators/impl/BasicHeaderValidatorSpec.scala
@@ -1,0 +1,60 @@
+/*
+ * Copyright 2018 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package uk.gov.hmrc.fraudprevention.headervalidators.impl
+
+import cats.data.Validated.{Invalid, Valid}
+import cats.data.ValidatedNel
+import uk.gov.hmrc.fraudprevention.headervalidators.HeaderValidator
+import uk.gov.hmrc.play.test.UnitSpec
+
+class BasicHeaderValidatorSpec extends HeaderValidatorBaseSpec with UnitSpec {
+
+  val basicHeaderValidators = List(
+    GovClientDeviceIdHeaderValidator, GovClientUserIdHeaderValidator, GovClientTimezoneHeaderValidator,
+    GovClientLocalIpHeaderValidator, GovVendorVersionHeaderValidator, GovVendorLicenseIdHeaderValidator,
+    GovClientConnectionMethodHeaderValidator
+  )
+
+  basicHeaderValidators foreach { headerValidator: HeaderValidator =>
+    headerValidator.getClass.getSimpleName should {
+
+      "return a valid result if the value is valid" in {
+        val headerValues = Some(Seq("test"))
+        val result: ValidatedNel[String, Unit] = validateRequest(headerValidator, headerValues)
+        result shouldBe Valid(())
+      }
+
+      s"fail to validate the ${headerValidator.headerName} header if there is no value" in {
+        val headerValues = None
+        val Invalid(nel) = validateRequest(headerValidator, headerValues)
+        nel.toList shouldBe List(s"Header ${headerValidator.headerName} is missing")
+      }
+
+      s"fail to validate the ${headerValidator.headerName} header if it is the empty string" in {
+        val headerValues = Some(Seq(""))
+        val Invalid(nel) = validateRequest(headerValidator, headerValues)
+        nel.toList shouldBe List(s"${headerValidator.headerName} must not be empty")
+      }
+
+      s"fail to validate the ${headerValidator.headerName} header if there are multiple values" in {
+        val headerValues = Some(Seq("12", "24"))
+        val Invalid(nel) = validateRequest(headerValidator, headerValues)
+        nel.toList shouldBe List(s"Multiple values for header ${headerValidator.headerName}")
+      }
+    }
+  }
+}

--- a/src/test/scala/uk/gov/hmrc/fraudprevention/headervalidators/impl/GovClientColourDepthHeaderValidatorSpec.scala
+++ b/src/test/scala/uk/gov/hmrc/fraudprevention/headervalidators/impl/GovClientColourDepthHeaderValidatorSpec.scala
@@ -23,47 +23,47 @@ import uk.gov.hmrc.play.test.UnitSpec
 
 class GovClientColourDepthHeaderValidatorSpec extends HeaderValidatorBaseSpec with UnitSpec {
 
-  override protected val headerValidator: HeaderValidator = GovClientColourDepthHeaderValidator
+  val headerValidator: HeaderValidator = GovClientColourDepthHeaderValidator
 
   "GovClientColourDepthHeaderValidator" should {
 
     s"fail to validate the ${headerValidator.headerName} header if there is no value" in {
       val headerValues = None
-      val Invalid(nel) = validateRequest(headerValues)
+      val Invalid(nel) = validateRequest(headerValidator, headerValues)
       nel.toList shouldBe List(s"Header ${headerValidator.headerName} is missing")
     }
 
     s"fail to validate the ${headerValidator.headerName} header if it is the empty string" in {
       val value = ""
       val headerValues = Some(Seq(value))
-      val Invalid(nel) = validateRequest(headerValues)
+      val Invalid(nel) = validateRequest(headerValidator, headerValues)
       nel.toList shouldBe List(s"Regular expression not matching for header ${headerValidator.headerName}: $value")
     }
 
     s"fail to validate the ${headerValidator.headerName} header if it does not contain a number" in {
       val value = "a"
       val headerValues = Some(Seq(value))
-      val Invalid(nel) = validateRequest(headerValues)
+      val Invalid(nel) = validateRequest(headerValidator, headerValues)
       nel.toList shouldBe List(s"Regular expression not matching for header ${headerValidator.headerName}: $value")
     }
 
     s"fail to validate the ${headerValidator.headerName} header if it is a negative number" in {
       val value = -4
       val headerValues = Some(Seq(value.toString))
-      val Invalid(nel) = validateRequest(headerValues)
+      val Invalid(nel) = validateRequest(headerValidator, headerValues)
       nel.toList shouldBe List(s"Regular expression not matching for header ${headerValidator.headerName}: $value")
     }
 
     s"fail to validate the ${headerValidator.headerName} header if it is a decimal number" in {
       val value = 34.165
       val headerValues = Some(Seq(value.toString))
-      val Invalid(nel) = validateRequest(headerValues)
+      val Invalid(nel) = validateRequest(headerValidator, headerValues)
       nel.toList shouldBe List(s"Regular expression not matching for header ${headerValidator.headerName}: $value")
     }
 
     s"fail to validate the ${headerValidator.headerName} header if there are multiple values" in {
       val headerValues = Some(Seq("12", "24"))
-      val Invalid(nel) = validateRequest(headerValues)
+      val Invalid(nel) = validateRequest(headerValidator, headerValues)
       nel.toList shouldBe List(s"Multiple values for header ${headerValidator.headerName}")
     }
 
@@ -72,7 +72,7 @@ class GovClientColourDepthHeaderValidatorSpec extends HeaderValidatorBaseSpec wi
         for (d2 <- 0 to 9) {
           for (d3 <- 0 to 9) {
             val headerValues = Some(Seq(s"$d1$d2$d3"))
-            validateRequest(headerValues) shouldBe ().validNel
+            validateRequest(headerValidator, headerValues) shouldBe ().validNel
           }
         }
       }

--- a/src/test/scala/uk/gov/hmrc/fraudprevention/headervalidators/impl/GovClientPublicPortHeaderValidatorSpec.scala
+++ b/src/test/scala/uk/gov/hmrc/fraudprevention/headervalidators/impl/GovClientPublicPortHeaderValidatorSpec.scala
@@ -23,68 +23,68 @@ import uk.gov.hmrc.play.test.UnitSpec
 
 class GovClientPublicPortHeaderValidatorSpec extends HeaderValidatorBaseSpec with UnitSpec {
 
-  override protected val headerValidator: HeaderValidator = GovClientPublicPortHeaderValidator
+  val headerValidator: HeaderValidator = GovClientPublicPortHeaderValidator
 
   "GovClientPublicPortHeaderValidator" should {
 
     s"fail to validate the ${headerValidator.headerName} header if there is no value" in {
       val headerValues = None
-      val Invalid(nel) = validateRequest(headerValues)
+      val Invalid(nel) = validateRequest(headerValidator, headerValues)
       nel.toList shouldBe List(s"Header ${headerValidator.headerName} is missing")
     }
 
     s"fail to validate the ${headerValidator.headerName} header if it is the empty string" in {
       val port = ""
       val headerValues = Some(Seq(port))
-      val Invalid(nel) = validateRequest(headerValues)
+      val Invalid(nel) = validateRequest(headerValidator, headerValues)
       nel.toList shouldBe List(s"Invalid port number for header ${headerValidator.headerName}: $port")
     }
 
     s"fail to validate the ${headerValidator.headerName} header if it does not contain a number" in {
       val port = "a"
       val headerValues = Some(Seq(port))
-      val Invalid(nel) = validateRequest(headerValues)
+      val Invalid(nel) = validateRequest(headerValidator, headerValues)
       nel.toList shouldBe List(s"Invalid port number for header ${headerValidator.headerName}: $port")
     }
 
     s"fail to validate the ${headerValidator.headerName} header if it is a negative number" in {
       val port = -4
       val headerValues = Some(Seq(port.toString))
-      val Invalid(nel) = validateRequest(headerValues)
+      val Invalid(nel) = validateRequest(headerValidator, headerValues)
       nel.toList shouldBe List(s"Invalid port number for header ${headerValidator.headerName}: $port")
     }
 
     s"fail to validate the ${headerValidator.headerName} header if it is zero" in {
       val port = 0
       val headerValues = Some(Seq(port.toString))
-      val Invalid(nel) = validateRequest(headerValues)
+      val Invalid(nel) = validateRequest(headerValidator, headerValues)
       nel.toList shouldBe List(s"Invalid port number for header ${headerValidator.headerName}: $port")
     }
 
     s"fail to validate the ${headerValidator.headerName} header if it bigger than 65535" in {
       val port = 65536
       val headerValues = Some(Seq(port.toString))
-      val Invalid(nel) = validateRequest(headerValues)
+      val Invalid(nel) = validateRequest(headerValidator, headerValues)
       nel.toList shouldBe List(s"Invalid port number for header ${headerValidator.headerName}: $port")
     }
 
     s"fail to validate the ${headerValidator.headerName} header if it is a decimal number" in {
       val port = 0.165
       val headerValues = Some(Seq(port.toString))
-      val Invalid(nel) = validateRequest(headerValues)
+      val Invalid(nel) = validateRequest(headerValidator, headerValues)
       nel.toList shouldBe List(s"Invalid port number for header ${headerValidator.headerName}: $port")
     }
 
     s"fail to validate the ${headerValidator.headerName} header if there are multiple values" in {
       val headerValues = Some(Seq("2333", "4445"))
-      val Invalid(nel) = validateRequest(headerValues)
+      val Invalid(nel) = validateRequest(headerValidator, headerValues)
       nel.toList shouldBe List(s"Multiple values for header ${headerValidator.headerName}")
     }
 
     s"validate the ${headerValidator.headerName} header if it is an allowed port number" in {
       for (p <- 1 to 65535) {
         val headerValues = Some(Seq(s"$p"))
-        validateRequest(headerValues) shouldBe ().validNel
+        validateRequest(headerValidator, headerValues) shouldBe ().validNel
       }
     }
 

--- a/src/test/scala/uk/gov/hmrc/fraudprevention/headervalidators/impl/HeaderValidatorBaseSpec.scala
+++ b/src/test/scala/uk/gov/hmrc/fraudprevention/headervalidators/impl/HeaderValidatorBaseSpec.scala
@@ -31,9 +31,7 @@ trait HeaderValidatorBaseSpec extends UnitSpec {
     }
   }
 
-  protected def headerValidator: HeaderValidator
-
-  protected def validateRequest(headerValues: Option[Seq[String]]): HeadersValidation = {
+  protected def validateRequest(headerValidator: HeaderValidator, headerValues: Option[Seq[String]]): HeadersValidation = {
     val request = buildRequest(headerValues, headerValidator.headerName)
     headerValidator.validate(request)
   }


### PR DESCRIPTION
…a set of default headers that don't need to be specified. The new headers have a common basic validation for now.